### PR TITLE
Formatting and convention update

### DIFF
--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/HardwarePushbot.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/HardwarePushbot.java
@@ -21,8 +21,7 @@ import com.qualcomm.robotcore.util.ElapsedTime;
  * Servo channel:  Servo to open left claw:  "left_hand"
  * Servo channel:  Servo to open right claw: "right_hand"
  */
-public class HardwarePushbot
-{
+public class HardwarePushbot {
     /* Public OpMode members. */
     public DcMotor  leftMotor   = null;
     public DcMotor  rightMotor  = null;
@@ -35,7 +34,7 @@ public class HardwarePushbot
     public static final double ARM_DOWN_POWER  = -0.45 ;
 
     /* local OpMode members. */
-    HardwareMap hwMap           =  null;
+    private HardwareMap hwMap   =  null;
     private ElapsedTime period  = new ElapsedTime();
 
     /* Constructor */
@@ -82,17 +81,15 @@ public class HardwarePushbot
      * @param periodMs  Length of wait cycle in mSec.
      */
     public void waitForTick(long periodMs) {
-
         long  remaining = periodMs - (long)period.milliseconds();
 
         // sleep for the remaining portion of the regular cycle period.
-        if (remaining > 0) {
+        if (remaining > 0)
             try {
                 Thread.sleep(remaining);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
-        }
 
         // Reset the cycle clock for the next pass.
         period.reset();


### PR DESCRIPTION
Before issuing a pull request, please see the contributing page.

The other variables have `public`, `private`, or `protected` identifiers, why not the HardwareMap? This isn't an important issue, but it definitely improves readability to be consistent with conventions.